### PR TITLE
WordPress 6.8 Compatibility

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,15 +1,24 @@
 # Changelog
 
-## 1.3.4
+## [1.3.5] - 2025-07-18
+
+- WordPress 6.8 compatibility
+- tested up to 6.8.2
+
+## [1.3.4] - 2024-10-30
+
 - Compatibility with WordPress 6.7 (2024-10-30)
 
-## 1.3.3
+## [1.3.3]
+
 - WordPress 6.6 compatibility
 
-## 1.3.2
+## [1.3.2]
+
 - WordPress 6.5 compatibility
 
-## 1.3.0
+## [1.3.0]
+
 - Compatibility Release for WordPress 6.3 (tested with RC2 beta) (2023-08-02)
 - Change dashboard title to avoid perceived false positive "warning" status
   see: https://github.com/openmindculture/wp-incompatibility-status/issues/9

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"require": {
-		"php": "^7.4"
+		"php": "^7.2 || ^8.2"
 	},
 	"require-dev": {
 		"squizlabs/php_codesniffer": "^3.7.1",
@@ -22,7 +22,7 @@
 		"optimize-autoloader": true,
 		"sort-packages": true,
 		"platform": {
-			"php": "7.4"
+			"php": "^7.2 || ^8.2"
 		}
 	},
 	"extra": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.3'
 services:
 
   db:
@@ -19,7 +18,7 @@ services:
     depends_on:
       - db
     # image: 'wordpress:latest'
-    image: 'wordpress:beta-6.7-RC2-php8.1'
+    image: 'wordpress:6.8-php8.4-apache'
     ports:
       - '8000:80'
     environment:

--- a/incompatibility-status/trunk/readme.txt
+++ b/incompatibility-status/trunk/readme.txt
@@ -2,9 +2,9 @@
 Contributors: openmindculture
 Tags: compatibility, incompatibility, check, status, admin
 Requires at least: 6.0
-Tested up to: 6.7
-Requires PHP: 7.4
-Stable tag: 1.3.3
+Tested up to: 6.8.2
+Requires PHP: 7.2
+Stable tag: 1.3.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
- support broader PHP version range
- support WordPress 6.8